### PR TITLE
empty responses were not sent by mung.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ mung.json = function json (fn) {
 
             // If null, then 204 No Content
             if (json === null)
-                return res.status(204);
+                return res.status(204).end();
 
             // If scalar value, then text/plain
             if (isScalar(json)) {

--- a/test/json.js
+++ b/test/json.js
@@ -41,7 +41,7 @@ describe ('mung json', () => {
     it('should return 204 on null JSON result', done => {
         let server = express()
             .use(mung.json(remove))
-            .get('/', (req, res) => res.status(200).json({ a: 'a' }).end());
+            .get('/', (req, res) => res.status(200).json({ a: 'a' }));
         request(server)
             .get('/')
             .expect(204)


### PR DESCRIPTION
when passing `res.json(null)` the requests were never sent
fixed by adding the missing `.end()` method