### PR TITLE
Add `mung.send` and `mung.sendAsync` implementations

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,14 +223,13 @@ mung.send = function (fn, options = {}) {
             } catch (err) {
                 return mung.onError(err, req, res, next);
             }
-            // If no returned value from fn, then set it back to the original value
-            if (modified === undefined) {
-                modified = data;
-            }
-
             // If the resp has completed,  do nothing
             if (res.finished) {
                 return res;
+            }
+            // If no returned value from fn, then set it back to the original value
+            if (modified === undefined) {
+                modified = data;
             }
 
             // Do not mung on errors
@@ -275,6 +274,11 @@ mung.sendAsync = function (fn, options = {}) {
                     if (res.finished) {
                         return;
                     }
+                    // If no returned value from the promise, then set it back to the original value
+                    if (modified === undefined) {
+                        modified = data;
+                    }
+
                     // Do not mung on errors
                     if (!options.mungError && res.statusCode >= 400) {
                         originalSend.call(res, data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-mung",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/send.js
+++ b/test/send.js
@@ -1,0 +1,150 @@
+'use strict';
+
+let should = require('should'),
+    express = require('express'),
+    request = require('supertest'),
+    mung = require('..');
+
+describe('mung send', () => {
+
+    let originalResponseTextBody
+    let modifiedResponseTextBody
+    let originalResponseJSONBody
+    let modifiedResponseJsonBody
+
+    beforeEach(() => {
+        originalResponseTextBody = 'This is the response body'
+        modifiedResponseTextBody = 'This is the response body with more content';
+        originalResponseJSONBody = {
+            a: 'a'
+        },
+        modifiedResponseJsonBody = {
+            a: 'a',
+            b: 'b',
+        }
+    })
+
+    function appendText (data, req, res) {
+        return (data + ' with more content')
+    }
+
+    function inspectJson (data, req, res) {
+        data.b = 'b';
+        return JSON.parse(JSON.stringify(data));
+    }
+
+    function remove (data, req, res) {
+        return null;
+    }
+
+    function error (data, req, res) {
+        data.foo.bar.hopefully.fails();
+    }
+
+    function error403 (data, req, res) {
+        res.status(403).json({ foo: 'bar '})
+    }
+
+    it('should return the munged text result', done => {
+        const server = express()
+            .use(mung.send(appendText))
+            .get('/', (req, res) => {
+                res.send(originalResponseTextBody);
+            });
+        request(server)
+            .get('/')
+            .expect(200)
+            .expect(res => {
+                res.text.should.eql(modifiedResponseTextBody);
+            })
+            .end(done);
+    });
+
+    it('should return a munged json body ', done => {
+        const server = express()
+            .use(mung.send(inspectJson))
+            .get('/', (req, res) => {
+                res.send(originalResponseJSONBody);
+            });
+        request(server)
+            .get('/')
+            .expect(200)
+            .expect(res => {
+                res.body.should.eql(modifiedResponseJsonBody);
+            })
+            .end(done);
+    });
+
+    it('should not mung an error response (by default)', done => {
+        const server = express()
+            .use(mung.send(appendText))
+            .get('/', (req, res) => {
+                res.status(404)
+                    .send(originalResponseTextBody);
+            });
+        request(server)
+            .get('/')
+            .expect(404)
+            .expect(res => {
+                res.text.should.equal(originalResponseTextBody)
+                res.body.should.deepEqual({});
+            })
+            .end(done);
+    });
+
+    it('should mung an error response when told to', done => {
+        const server = express()
+            .use(mung.send(appendText, { mungError: true }))
+            .get('/', (req, res) => {
+                res.status(404)
+                    .send(originalResponseTextBody);
+            });
+        request(server)
+            .get('/')
+            .expect(404)
+            .expect(res => {
+                res.text.should.eql(modifiedResponseTextBody);
+            })
+            .end(done);
+    });
+
+    it('should abort if a response is sent', done => {
+        const server = express()
+            .use(mung.send(error403))
+            .get('/', (req, res) => {
+                res.status(200)
+                    .send(originalResponseTextBody)
+            });
+        request(server)
+            .get('/')
+            .expect(403)
+            .end(done);
+    });
+
+    it('should 500 on a synchronous exception', done => {
+        const server = express()
+            .use(mung.send(error))
+            .get('/', (req, res) => {
+                res.status(200)
+                    .send(originalResponseTextBody);
+            });
+        request(server)
+            .get('/')
+            .expect(500)
+            .end(done);
+    });
+
+    it('should 500 on an asynchronous exception', done => {
+        const server = express()
+            .use(mung.send(error))
+            .get('/', (req, res) => {
+                process.nextTick(() => {
+                    res.status(200).send(originalResponseTextBody);
+                });
+            });
+        request(server)
+            .get('/')
+            .expect(500)
+            .end(done);
+    });
+})


### PR DESCRIPTION
Hi,  I tried to use it in a create-react-app project, and in my very special case,  the webpack-dev-server send html page content via `res.send` and I have the need to modify it through middlewares.

 I found that it will be good if `mung.send` and `mung.sendAsync` were provided, so I tried to add the implementations in this pull request. 

Please check the codes if they are acceptable, Thanks!